### PR TITLE
Update test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -244,7 +244,7 @@ def main():
                 domain=DOMAINS[args.dataset],
             )
             df.loc[len(df)] = Series(class_result_dict)
-        df.loc[len(df)] = df.mean()
+        df.loc[len(df)] = df.mean(numeric_only=True)
         df.loc[len(df) - 1]["class name"] = "Average"
         logger.info("final results:\n%s", df.to_string(index=False, justify="center"))
 


### PR DESCRIPTION
When testing the trained model on ViSA using MvTec following error occurs:
![Screenshot 2025-07-06 221046](https://github.com/user-attachments/assets/b8f94656-af87-4a62-b170-198d9b1a349b)

which is caused as the class name column is used to compute mean. It can be avoided by just making use of numerical columns by making the following change:
**df.loc[len(df)] = df.mean(numeric_only=True)**
